### PR TITLE
implement for android 17(sdk 37)

### DIFF
--- a/zygisk/jni/module.cpp
+++ b/zygisk/jni/module.cpp
@@ -22,6 +22,8 @@
 static int sdk = 0;
 static uint32_t relayout_code = 0;
 static uint32_t relayoutAsync_code = 0;
+static uint32_t relayout2_code = 0;
+static uint32_t relayoutAsync2_code = 0;
 static uint32_t registerScreenCaptureObserver_code = 0;
 
 static const char* PROC_NAME = "";
@@ -31,6 +33,14 @@ static bool getTransactionCodes(JNIEnv* env) {
     relayoutAsync_code = getStaticIntFieldJni(env, STUB("android/view/IWindowSession"), TRSCTN("relayoutAsync"));
     registerScreenCaptureObserver_code =
         getStaticIntFieldJni(env, STUB("android/app/IActivityTaskManager"), TRSCTN("registerScreenCaptureObserver"));
+
+    // Optional, introduced since 37, maybe removed in the future.
+    // See
+    // https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/java/android/view/IWindowSession.aidl#93
+    relayout2_code = getStaticIntFieldJni(
+        env, STUB("android/view/IWindowSession"), TRSCTN("relayout2"));
+    relayoutAsync2_code = getStaticIntFieldJni(
+        env, STUB("android/view/IWindowSession"), TRSCTN("relayoutAsync2"));
 
     if (registerScreenCaptureObserver_code == 0 && relayoutAsync_code == 0 && relayout_code == 0) {
         LOGD("ERROR getTransactionCodes: Could not get any transaction codes");
@@ -54,7 +64,9 @@ int transactHook(void* self, int32_t handle, uint32_t code, void* pdata, void* p
     auto descLen = parcel.readInt32();
     auto desc = parcel.readString16(descLen);
 
-    if ((code == relayout_code || code == relayoutAsync_code) &&
+    if ((code == relayout_code || code == relayoutAsync_code ||
+         (0 != relayout2_code && code == relayout2_code) ||
+         (0 != relayoutAsync2_code && code == relayoutAsync2_code)) &&
         STR_LEN(I_WINDOW_SESSION_DESC) == descLen &&
         memcmp(desc, I_WINDOW_SESSION_DESC, descLen * sizeof(char16_t)) == 0) {
         // remove FLAG_SECURE mask


### PR DESCRIPTION
[Two new methods](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/java/android/view/IWindowSession.aidl#93) was added in android 17 (sdk 37) : 

However they planned to remove these two methods in the future, so i made these method optional.

Tested under: Pixel 6, Android 17


--------

Off-topic:
Would you mind providing Android.mk and Application.mk and build/package script ? Currently i use the script from https://github.com/topjohnwu/zygisk-module-sample/tree/master/module/jni with some modification and then following the building and packaing step from https://github.com/topjohnwu/zygisk-module-sample#building

`zygisk/jni/Android.mk `
```Makefile
LOCAL_PATH := $(call my-dir)

include $(CLEAR_VARS)
LOCAL_MODULE := module
LOCAL_SRC_FILES := module.cpp binder.cpp
LOCAL_LDLIBS := -llog -lstdc++
include $(BUILD_SHARED_LIBRARY)
```

`zygisk/jni/Application.mk`
```Makefile
APP_ABI      := armeabi-v7a arm64-v8a x86 x86_64
APP_CPPFLAGS := -std=c++17 -fno-exceptions -fno-rtti -fvisibility=hidden -fvisibility-inlines-hidden
APP_STL      := none
# Android 10 (sdk29) ~
APP_PLATFORM := android-29
```

